### PR TITLE
Update gray tone 500 to match Figma design

### DIFF
--- a/styling/html-styling.css
+++ b/styling/html-styling.css
@@ -81,7 +81,7 @@
   --primary-500: hsl(202, 100%, 34%);
   --primary-700: hsl(205, 100%, 23%);
   --primary-900: hsl(208, 100%, 19%);
-  --gray-500: hsl(208, 34%, 46%);
+  --gray-500: hsl(208, 24%, 40%);
   --text-muted: var(--gray-500);
 }
 


### PR DESCRIPTION
@reinaldoarrosi This PR updates the gray tone 500 to match what's in our repository and Figma files today.

This PR is related to [this commit](https://bitbucket.org/gemmeus/testdome/commits/9a3651a815b023a8822010034aaf55414cd44de9) that's part of [DEV-4117](https://gemmeus.atlassian.net/browse/DEV-4117).