### PR TITLE
Update book image border radius to follow Figma styles

### DIFF
--- a/styling/html-styling.css
+++ b/styling/html-styling.css
@@ -377,7 +377,7 @@ table td {
   float: right;
   height: 340px;
   margin: 0 20px;
-  border-radius: 0.25rem;
+  border-radius: 0.5rem;
 }
 
 #page-footer {


### PR DESCRIPTION
This PR updates the border radius of the book image.

It is just an update from 4px to 8px (`0.5rem`) because the TestDome Design System already uses that value as `border-radius` for many other elements, like buttons and inputs.

This PR is related to [this commit](https://bitbucket.org/gemmeus/testdome/commits/eb4157dae287c9894642195ce377cd666182c543) that's part of [DEV-4117](https://gemmeus.atlassian.net/browse/DEV-4117).