### PR TITLE
Spliting the book into multiple HTML files

### DIFF
--- a/md2all.bat
+++ b/md2all.bat
@@ -5,8 +5,22 @@ pushd source
 set front=front-matter.md
 set content=chapter1.md chapter2.md chapter3.md chapter4.md chapter5.md chapter6.md chapter7.md chapter8.md bonus-chapter.md back-matter.md
 
+@REM Create folders:
+if not exist ../output mkdir ../output
+if not exist ../output/web mkdir ../output/web
+
 @REM Build HTML:
-pandoc -s %front% %content% -o ../output/ebh.html --toc --section-divs --lua-filter ../styling/pagebreak.lua --lua-filter ../styling/html-open-links-in-new-tab.lua --lua-filter ../styling/html-lazy-images.lua --template ../styling/html-template.html
+pandoc --shift-heading-level-by -1 --split-level 1 -t chunkedhtml -s %front% %content% -o ../output/web/ebh --toc --section-divs --lua-filter ../styling/pagebreak.lua --lua-filter ../styling/html-open-links-in-new-tab.lua --lua-filter ../styling/html-lazy-images.lua --template ../styling/html-template.html
+
+@REM Replacing index.html with licence.html:
+del ..\output\web\ebh\index.html
+rename ..\output\web\ebh\1-license.html index.html
+sed -i 's/1-license.html/index.html/g' ../output/web/ebh/*.html
+
+@REM Include styling and images in the output folder:
+cp -r ../styling ../output/web
+cp -r ../Amazon ../output/web
+cp -r ../images ../output/web
 
 @REM Build EPUB:
 pandoc -s %front% %content% -o ../output/ebh.epub --toc -c ../styling/epub-styling.css --lua-filter ../styling/pagebreak.lua 

--- a/md2all.bat
+++ b/md2all.bat
@@ -6,11 +6,11 @@ set front=front-matter.md
 set content=chapter1.md chapter2.md chapter3.md chapter4.md chapter5.md chapter6.md chapter7.md chapter8.md bonus-chapter.md back-matter.md
 
 @REM Create folders:
-if not exist ../output mkdir ../output
-if not exist ../output/web mkdir ../output/web
+if not exist ..\output mkdir ..\output
+if not exist ..\output\web mkdir ..\output\web
 
 @REM Build HTML:
-pandoc --shift-heading-level-by -1 --split-level 1 -t chunkedhtml -s %front% %content% -o ../output/web/ebh --toc --section-divs --lua-filter ../styling/pagebreak.lua --lua-filter ../styling/html-open-links-in-new-tab.lua --lua-filter ../styling/html-lazy-images.lua --template ../styling/html-template.html
+pandoc --split-level 1 -t chunkedhtml -s %front% %content% -o ../output/web/ebh --toc --section-divs --lua-filter ../styling/pagebreak.lua --lua-filter ../styling/html-open-links-in-new-tab.lua --lua-filter ../styling/html-lazy-images.lua --template ../styling/html-template.html
 
 @REM Replacing index.html with licence.html:
 del ..\output\web\ebh\index.html

--- a/styling/html-nav.js
+++ b/styling/html-nav.js
@@ -1,189 +1,33 @@
 (function() {
-    var frontPage, lastPage, copyright, chapters, sections, footnotes, currentPage, prevButtons, nextButtons;
-
-    function hide(el) {
-        el.style.display = 'none';
-    }
-
-    function show(el) {
-        el.style.display = null;
-    }
-
-    function goTo(hash) {
-        window.location.hash = hash || '';
-    }
-
-    function goToPrevious() {
-        if(!currentPage) {
-            return;
-        } else {
-            var index = chapters.findIndex(function(x) { return x.hash == currentPage.hash });
-            index--;
-
-            window.location.hash = chapters[index] ? chapters[index].hash : '';
-        }
-    }
-
-    function goToNext() {
-        var index = currentPage ? chapters.findIndex(function(x) { return x.hash == currentPage.hash }) : -1;
-        index++;
-
-        window.location.hash = chapters[index] ? chapters[index].hash : '';
-    }
-
-    function onHashChange() {
-        var hash = window.location.hash;
-
-        if (currentPage) {
-            hide(currentPage);
-        }
-
-        currentPage = getRootChapter(hash);
-
-        if (currentPage == null) {
-            show(frontPage);
-            show(copyright);
-        } else {
-            hide(frontPage);
-            hide(copyright);
-            show(currentPage);
-        }
-
-        if (currentPage == lastPage) {
-            show(footnotes);
-        } else {
-            hide(footnotes);
-        }
-
-        prevButtons.forEach(function(el) { el.disabled = currentPage == null; });
-        nextButtons.forEach(function(el) { el.disabled = currentPage == lastPage; });
-
-        setupShareButtons();
-        scrollToElement(window.location.hash);
-    }
-
-    function scrollToElement(selector) {
-        var element = selector ? document.querySelector(selector) : null;
-        window.scroll({ top: element ? element.offsetTop : 0, left: 0 });
-    }
-
-    function getRootChapter(hash) {
-        var section = sections.find(function (x) { return x.hash === hash; });
-        while (section && section.parentChapter) { section = section.parentChapter;}
-
-        return section;
-    }
-
-    function buildSubChapters(chapter, level) {
-        var subs = chapter.querySelectorAll('section.level' + level);
-        
-        subs.forEach(function(x) {
-            x.hash = '#' + x.id;
-            x.parentChapter = chapter;
-            
-            buildSubChapters(x, level + 1);
-
-            sections.push(x);
-        });
-    }
-
-    function buildFootnoteReferences(chapter) {
-        // use `sup` instead of `a` to avoid overriding the existing `hash` property of `a`
-        chapter.querySelectorAll('a[id^="fnref"] > sup').forEach(function(x) {
-            x.hash = '#' + x.parentElement.id;
-            x.parentChapter = chapter;
-
-            sections.push(x);
-        });
-    }
-
-    function buildFootnotes(chapter, footnotes) {
-        footnotes.forEach(function(x) {
-            x.hash = '#' + x.id;
-            x.parentChapter = chapter;
-
-            sections.push(x);
-        });
-    }
-
-    function setupShareButtons() {
-        var shareButtonsContainer = document.getElementById('share-buttons');
-        show(shareButtonsContainer);
-
-        var shareButtons = shareButtonsContainer.getElementsByTagName('a');
-        for(var i = 0; i < shareButtons.length; i++) {
-            var button = shareButtons[i];
-
-            button.href = button.dataset.hrefTemplate
-                .replace('{url}', encodeURIComponent(window.location.href))
-                .replace('{title}', 'Evidence-Based Hiring')
-        }
-    }
-
-    function init() {
-        if (typeof (document.querySelector) !== 'function') {
-            // if the browser doesn't the apis we need
-            // keep the book in a single HTML page
-            return;
-        }
-
-        if ('scrollRestoration' in history) {
-            // disable auto scroll restoration to avoid
-            // since we control scroll position ourselves
-            history.scrollRestoration = 'manual';
-        }
-
-        setupShareButtons();
-
-        var title = document.querySelector('h1.title');
-        title.addEventListener('click', function() {
-            goTo(null);
-            scrollToElement(null);
-        });
-
-        var tocButton = document.querySelector('button#toc-button');
-        tocButton.addEventListener('click', function() {
-            goTo('#toc-title');
-            scrollToElement('#toc-title');
-        });
-
-        frontPage = document.querySelector('#front-page');
-
-        copyright = document.querySelector('section#copyright'); 
-
-        sections = [];
-        chapters = [];
-        document.querySelectorAll('section.level2')
-            .forEach(function(x) { 
-                x.hash = '#' + x.id;
-                x.style.display = 'none';
-
-                buildSubChapters(x, 3);
-
-                sections.push(x);
-                chapters.push(x);
-
-                buildFootnoteReferences(x);
+    // Include table of contents only on the "license" page.
+    // This is a workaround for the fact that the book currently "merges" the
+    // "Table of Contents" page with the "License" page.
+    document.addEventListener('DOMContentLoaded', function() {
+        const licenseElement = document.getElementById('license');
+        if (licenseElement) {
+            // Show the table of contents.
+            const frontPageElement = document.getElementById('front-page');
+            frontPageElement.style.display = 'block';
+            // Disable the previous buttons for the first page (license).
+            const prevButtonElements = document.querySelectorAll('.prev-button');
+            prevButtonElements.forEach(function(prevButtonElement) {
+                prevButtonElement.disabled = true;
+            });
+            const prevLinkElements = document.querySelectorAll('.prev-link');
+            prevLinkElements.forEach(function(prevLinkElement) {
+                prevLinkElement.href = '#';
             });
 
-        lastPage = chapters[chapters.length - 1];
+        }
 
-        footnotes = document.querySelector('section.footnotes'); 
-        footnotes.style.display = 'none';
-        buildFootnotes(lastPage, footnotes.querySelectorAll('li[id^="fn"]'));
+        const aboutTheAuthorElement = document.getElementById('about-the-author');
+        if (aboutTheAuthorElement) {
+            // Disable the next buttons for the last page (about the author).
+            const nextButtonElements = document.querySelectorAll('.next-button');
+            nextButtonElements.forEach(function(nextButtonElement) {
+                nextButtonElement.disabled = true;
+            });
+        }
 
-        prevButtons = document.querySelectorAll('.prev-button');
-        prevButtons.forEach(function(el) { el.addEventListener('click', goToPrevious); });
-
-        nextButtons = document.querySelectorAll('.next-button');
-        nextButtons.forEach(function(el) { el.addEventListener('click', goToNext); });
-
-        window.addEventListener('hashchange', function() { onHashChange(); });
-       
-        // trigger onHashChange the first time the page loads
-        // to make sure the correct chapter is displayed.
-        onHashChange();
-    }
-
-    init();
+    });
 })()

--- a/styling/html-styling.css
+++ b/styling/html-styling.css
@@ -188,6 +188,23 @@ h1 {
   line-height: 1;
 }
 
+/* Force titles inside sections to be smaller. */
+section h1 {
+  font-size: 2rem;
+}
+
+section h2 {
+  font-size: 1.5rem;
+}
+
+section h4 {
+  font-size: 1rem;
+}
+
+section h5 {
+  font-size: 0.9rem;
+}
+
 h2 {
   font-size: 2rem;
 }

--- a/styling/html-template.html
+++ b/styling/html-template.html
@@ -70,28 +70,31 @@ $if(title)$
   <h1 class="title">$title$</h1>
 
   <span id="nav-buttons-header">
-    <button class="prev-button btn btn-translucent">
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512">
-        <path
-          d="M20.2 247.5L167 99.5c4.7-4.7 12.3-4.7 17 0l19.8 19.8c4.7 4.7 4.7 12.3 0 17L85.3 256l118.5 119.7c4.7 4.7 4.7 12.3 0 17L184 412.5c-4.7 4.7-12.3 4.7-17 0l-146.8-148c-4.7-4.7-4.7-12.3 0-17zm160 17l146.8 148c4.7 4.7 12.3 4.7 17 0l19.8-19.8c4.7-4.7 4.7-12.3 0-17L245.3 256l118.5-119.7c4.7-4.7 4.7-12.3 0-17L344 99.5c-4.7-4.7-12.3-4.7-17 0l-146.8 148c-4.7 4.7-4.7 12.3 0 17z" />
-      </svg>
-      <span>Previous</span>
-    </button>
-    <button id="toc-button" class="btn btn-translucent">Table of Contents</button>
-    <button class="next-button btn btn-translucent">
-      <span>Next</span>
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512">
-        <path
-          d="M363.8 264.5L217 412.5c-4.7 4.7-12.3 4.7-17 0l-19.8-19.8c-4.7-4.7-4.7-12.3 0-17L298.7 256 180.2 136.3c-4.7-4.7-4.7-12.3 0-17L200 99.5c4.7-4.7 12.3-4.7 17 0l146.8 148c4.7 4.7 4.7 12.3 0 17zm-160-17L57 99.5c-4.7-4.7-12.3-4.7-17 0l-19.8 19.8c-4.7 4.7-4.7 12.3 0 17L138.7 256 20.2 375.7c-4.7 4.7-4.7 12.3 0 17L40 412.5c4.7 4.7 12.3 4.7 17 0l146.8-148c4.7-4.7 4.7-12.3 0-17z" />
-      </svg>
-    </button>
+    <a class="prev-link" href="$previous.url$">
+      <button class="prev-button btn btn-translucent">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512">
+          <path
+            d="M20.2 247.5L167 99.5c4.7-4.7 12.3-4.7 17 0l19.8 19.8c4.7 4.7 4.7 12.3 0 17L85.3 256l118.5 119.7c4.7 4.7 4.7 12.3 0 17L184 412.5c-4.7 4.7-12.3 4.7-17 0l-146.8-148c-4.7-4.7-4.7-12.3 0-17zm160 17l146.8 148c4.7 4.7 12.3 4.7 17 0l19.8-19.8c4.7-4.7 4.7-12.3 0-17L245.3 256l118.5-119.7c4.7-4.7 4.7-12.3 0-17L344 99.5c-4.7-4.7-12.3-4.7-17 0l-146.8 148c-4.7 4.7-4.7 12.3 0 17z" />
+        </svg>
+        <span>Previous</span>
+      </button>
+    </a>
+    <a href="$top.url$#toc-title" id="toc-button" class="btn btn-translucent">Table of Contents</a>
+    <a href="$next.url$">
+      <button class="next-button btn btn-translucent">
+        <span>Next</span>
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512">
+          <path
+            d="M363.8 264.5L217 412.5c-4.7 4.7-12.3 4.7-17 0l-19.8-19.8c-4.7-4.7-4.7-12.3 0-17L298.7 256 180.2 136.3c-4.7-4.7-4.7-12.3 0-17L200 99.5c4.7-4.7 12.3-4.7 17 0l146.8 148c4.7 4.7 4.7 12.3 0 17zm-160-17L57 99.5c-4.7-4.7-12.3-4.7-17 0l-19.8 19.8c-4.7 4.7-4.7 12.3 0 17L138.7 256 20.2 375.7c-4.7 4.7-4.7 12.3 0 17L40 412.5c4.7 4.7 12.3 4.7 17 0l146.8-148c4.7-4.7 4.7-12.3 0-17z" />
+        </svg>
+      </button>
+    </a>
   </span>
 </header>
 $endif$
 
 <main>
-
-<div id="front-page">
+<div style="display:none" id="front-page">
   <div id="front-page-summary">
     <img src="../images/ebh-cover-image-extra-small.jpg" id="front-page-image" />
     <h2 style="text-align: left">About the Book</h2>
@@ -130,15 +133,12 @@ $endif$
     </div>
   </div>
   <hr>
-  $if(toc)$
   <h2 id="toc-title" style="text-align: left;">Table of contents</h2>
   <nav id="$idprefix$TOC" role="doc-toc">
   $table-of-contents$
   </nav>
   <hr>
-  $endif$
 </div>
-
 $body$
 </main>
 
@@ -159,20 +159,24 @@ $body$
   </span>
 
   <span id="nav-buttons-footer">
-    <button class="prev-button btn btn-translucent">
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512">
-        <path
-          d="M20.2 247.5L167 99.5c4.7-4.7 12.3-4.7 17 0l19.8 19.8c4.7 4.7 4.7 12.3 0 17L85.3 256l118.5 119.7c4.7 4.7 4.7 12.3 0 17L184 412.5c-4.7 4.7-12.3 4.7-17 0l-146.8-148c-4.7-4.7-4.7-12.3 0-17zm160 17l146.8 148c4.7 4.7 12.3 4.7 17 0l19.8-19.8c4.7-4.7 4.7-12.3 0-17L245.3 256l118.5-119.7c4.7-4.7 4.7-12.3 0-17L344 99.5c-4.7-4.7-12.3-4.7-17 0l-146.8 148c-4.7 4.7-4.7 12.3 0 17z" />
-      </svg>
-      <span>Previous</span>
-    </button>
-    <button class="next-button btn btn-translucent">
-      <span>Next</span>
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512">
-        <path
-          d="M363.8 264.5L217 412.5c-4.7 4.7-12.3 4.7-17 0l-19.8-19.8c-4.7-4.7-4.7-12.3 0-17L298.7 256 180.2 136.3c-4.7-4.7-4.7-12.3 0-17L200 99.5c4.7-4.7 12.3-4.7 17 0l146.8 148c4.7 4.7 4.7 12.3 0 17zm-160-17L57 99.5c-4.7-4.7-12.3-4.7-17 0l-19.8 19.8c-4.7 4.7-4.7 12.3 0 17L138.7 256 20.2 375.7c-4.7 4.7-4.7 12.3 0 17L40 412.5c4.7 4.7 12.3 4.7 17 0l146.8-148c4.7-4.7 4.7-12.3 0-17z" />
-      </svg>
-    </button>
+    <a class="prev-link" href="$previous.url$">
+      <button class="prev-button btn btn-translucent">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512">
+          <path
+            d="M20.2 247.5L167 99.5c4.7-4.7 12.3-4.7 17 0l19.8 19.8c4.7 4.7 4.7 12.3 0 17L85.3 256l118.5 119.7c4.7 4.7 4.7 12.3 0 17L184 412.5c-4.7 4.7-12.3 4.7-17 0l-146.8-148c-4.7-4.7-4.7-12.3 0-17zm160 17l146.8 148c4.7 4.7 12.3 4.7 17 0l19.8-19.8c4.7-4.7 4.7-12.3 0-17L245.3 256l118.5-119.7c4.7-4.7 4.7-12.3 0-17L344 99.5c-4.7-4.7-12.3-4.7-17 0l-146.8 148c-4.7 4.7-4.7 12.3 0 17z" />
+        </svg>
+        <span>Previous</span>
+      </button>
+    </a>
+    <a href="$next.url$">
+      <button class="next-button btn btn-translucent">
+        <span>Next</span>
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512">
+          <path
+            d="M363.8 264.5L217 412.5c-4.7 4.7-12.3 4.7-17 0l-19.8-19.8c-4.7-4.7-4.7-12.3 0-17L298.7 256 180.2 136.3c-4.7-4.7-4.7-12.3 0-17L200 99.5c4.7-4.7 12.3-4.7 17 0l146.8 148c4.7 4.7 4.7 12.3 0 17zm-160-17L57 99.5c-4.7-4.7-12.3-4.7-17 0l-19.8 19.8c-4.7 4.7-4.7 12.3 0 17L138.7 256 20.2 375.7c-4.7 4.7-4.7 12.3 0 17L40 412.5c4.7 4.7 12.3 4.7 17 0l146.8-148c4.7-4.7 4.7-12.3 0-17z" />
+        </svg>
+      </button>
+    </a>
   </span>
 </footer>
 


### PR DESCRIPTION
This pull request changes the build script so it now uses the chunkedhtml option to generate multiple HTML files in the output. By using this option, Pandoc generates a folder with multiple HTML files and setups all the linking between those. It also includes a sitemap.json file. More information can be found here: 
https://pandoc.org/MANUAL.html#chunked-html

Another great feature is that the footnotes are shown on every page, with the corresponding references instead of as a list with all the references at the last chapter.

This option did not require us to keep most of the JS hacks anymore, but it did not work exactly how we expect out of the box, so some other changes were required.

By default, the generated index.html file does not include the front-matter content, so in order to keep the content from front-matter.md (the license) the following changes were required:

- Replacing the index.html file with the 1-license.html file. This is controlled by the bat script.
- Rendering the table of contents in every file, which is hidden by default and only shown when the user is on the license page. This is controlled by Javascript in runtime.
- Changing all links from 1-license.html file to index.html with the sed command. The sed tool It is installed with Git Bash by default on Windows, so I believe we will have no problems with this tool.

The heading was also not following the same pattern as before. Level 2 headings (h2) were being rendered as Level 1 (h1), so the default styles for heading elements inside sections were overwritten.